### PR TITLE
fix auth issues

### DIFF
--- a/hypercompose/api.py
+++ b/hypercompose/api.py
@@ -7,7 +7,7 @@ from requests import Session
 
 from dictns import Namespace
 
-from .requests_aws4auth import AWS4Auth
+from requests_aws4auth import AWS4Auth
 
 try:
     import httplib
@@ -49,7 +49,7 @@ class Hyper(Session):
     def get(self, *a, **kw):
         r = Session.get(self, *a, **kw)
         r.raise_for_status()
-        return Namespace(r.json)
+        return Namespace(r.json())
 
     def list_containers(self):
-        return self.get(self.url + "/containers/json")
+        return self.get(self.url + "/v1.23/containers/json", verify=False)

--- a/hypercompose/cmd.py
+++ b/hypercompose/cmd.py
@@ -5,7 +5,7 @@ from api import Hyper
 
 def do_up(args):
     h = args.hyper
-    print h.list_containers().json()
+    print h.list_containers()
 
 
 def do_down(args):
@@ -37,3 +37,5 @@ def main():
     args = parser.parse_args()
     args.hyper = Hyper(config=args.config)
     return args.func(args)
+
+if  __name__ =='__main__':main()


### PR DESCRIPTION
I am not very familiar with python, but this patch should work well, you may refer it and make the patch better.
### Test result

```
INFO:requests.packages.urllib3.connectionpool:Starting new HTTPS connection (1): 147.75.195.39
/usr/lib/python2.7/site-packages/requests/packages/urllib3/connectionpool.py:768: InsecureRequestWarning: Unverified HTTPS request is being made. Adding certificate verification is strongly advised. See: https://urllib3.readthedocs.org/en/latest/security.html
  InsecureRequestWarning)
send: u'GET /v1.23/containers/json HTTP/1.1\r\nHost: 147.75.195.39:6443\r\nAccept-Encoding: gzip, deflate\r\nx-hyper-content-sha256: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855\r\nAccept: */*\r\nUser-Agent: python-requests/2.7.0 CPython/2.7.5 Linux/3.10.0-327.10.1.el7.x86_64\r\nConnection: keep-alive\r\nAuthorization: HYPER-HMAC-SHA256 Credential=0PN5J17HBGZHT7JJ3X82/20160630/us-west-1/hyper/hyper_request, SignedHeaders=content-type;host;x-hyper-content-sha256;x-hyper-date, Signature=bb5b253d92ef5e439f7fce16191b101ceefa85c75a4a6c773c5110a3ee33b2ba\r\nContent-Type: application/json\r\nx-hyper-date: 20160630T083021Z\r\n\r\n'
reply: 'HTTP/1.1 200 OK\r\n'
header: Content-Type: application/json
header: Date: Thu, 30 Jun 2016 08:30:26 GMT
header: Content-Length: 1951
DEBUG:requests.packages.urllib3.connectionpool:"GET /v1.23/containers/json HTTP/1.1" 200 1951
[{
    "Status": "Up 4 hours",
    "Created": 1467260997,
    "Image": "busybox",
    "Labels": {
        "sh.hyper.fip": "",
        "sh_hyper_instancetype": "xs"
    },
    "HostConfig": {
        "NetworkMode": "bridge"
    },
    "ImageID": "sha256:2b8fd9751c4c0f5dd266fcae00707e67a2545ef34f9a29354585f93dac906749",
    "State": "",
    "Command": "sh",
    "Names": [
        "/parent",
        "/prickly-bardeen/test"
    ],
    "Id": "edd3968e80fafc75af32a03090867c7acb748a2ab059904a9f2e44504c86ae22",
    "Ports": [],
    "NetworkSettings": {
        "Networks": {
            "bridge": {
                "NetworkID": "",
                "MacAddress": "",
                "GlobalIPv6PrefixLen": 0,

▽
                "Links": null,
                "GlobalIPv6Address": "",

▽
                "IPAddress": "172.16.219.183",
                "Gateway": "",
                "IPPrefixLen": 0,
                "EndpointID": "",
                "IPv6Gateway": "",
                "IPAMConfig": null,
                "Aliases": null
            }
        }
    }
}, {
    "Status": "Up 4 hours",
    "Created": 1467260927,
    "Image": "busybox",
    "Labels": {
        "sh.hyper.fip": "",
        "sh_hyper_instancetype": "xs"
    },
    "HostConfig": {
        "NetworkMode": "bridge"
    },
    "ImageID": "sha256:2b8fd9751c4c0f5dd266fcae00707e67a2545ef34f9a29354585f93dac906749",
    "State": "",
    "Command": "sh",
    "Names": [
        "/condescending-knuth",
        "/gigantic-pare/test"
    ],
    "Id": "937e901a1e9de03f3619ddff3e610e07344f596e395a106762c327004437d91d",
    "Ports": [],
    "NetworkSettings": {
        "Networks": {
            "bridge": {
                "NetworkID": "",
                "MacAddress": "",
                "GlobalIPv6PrefixLen": 0,
                "Links": null,
                "GlobalIPv6Address": "",
                "IPAddress": "172.16.219.181",
                "Gateway": "",
                "IPPrefixLen": 0,
                "EndpointID": "",
                "IPv6Gateway": "",
                "IPAMConfig": null,
                "Aliases": null
            }
        }
    }
}]
```
